### PR TITLE
Fixed a marked check for the tmux 3.1 older versions

### DIFF
--- a/ranger_tmux/util.py
+++ b/ranger_tmux/util.py
@@ -67,9 +67,8 @@ def select_shell_pane(ranger_pane):
         return
 
     # Check for a marked pane in this window
-    has_marked_pane = int(
-        tmux("display", "-p", "-F", "#{window_marked_flag}", "-t", ranger_pane)
-    )
+    marks = tmux("display", "-p", "-F", "#{window_flags}", "-t", ranger_pane)
+    has_marked_pane = 'M' in marks  # marks' values can be `#!~*-MZ`
     if has_marked_pane:
         pane = tmux("display", "-p", "-t", "{marked}", "#{pane_id}")
         if pane in other_panes and pane != ranger_pane:


### PR DESCRIPTION
#3 

I removed previous check code as the current does check the older and newer tmux versions.

Window flags values found [here](https://github.com/tmux/tmux/blob/8ff3091d1677159150dee3791cd244029b9f47d3/window.c#L861)