### PR TITLE
Focus other pane after sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This plugin adds several settings to ranger:
 | Setting                   | Type  | Default | Meaning                                                                                  |
 | ------------------------- | ----- | ------- | ---------------------------------------------------------------------------------------- |
 | `tmux_cwd_sync`           | bool  | False   | When True, ranger's current directory is synced to the other pane                        |
+| `tmux_cwd_sync_now_focus` | bool  | False   | When True, the other pane will be focused after manually syncing it with ranger          |
 | `tmux_cwd_track`          | bool  | False   | When True, ranger's current directory tracks the other pane                              |
 | `tmux_cwd_track_interval` | float | 0.5     | Time between checks of the directory of the other pane when tracking                     |
 | `tmux_open_in_window`     | bool  | True    | When True, files opened with ranger will open in a new tmux window                       |

--- a/ranger_tmux/cwd_sync.py
+++ b/ranger_tmux/cwd_sync.py
@@ -1,26 +1,33 @@
 # -*- coding: utf-8 -*-
+"""Add options and commands for syncing panes to ranger's current working directory."""
+
 from ranger.api.commands import Command
 
 from . import util
 
 SETTINGS = {
     "tmux_cwd_sync": {"key": "s", "type": bool},
+    "tmux_cwd_sync_now_focus": {"type": bool},
 }
 
 
 class tmux_cwd_sync_now(Command):
+    """Sync working directory of the "other" pane to match ranger's."""
+
     ranger_pane = None
 
     def execute(self):
+        """Executes the command."""
         if self.ranger_pane:
             pane_id = util.select_shell_pane(self.ranger_pane)
             if pane_id:
                 util.cd_pane(self.fm.thisdir.path, pane_id)
+                if self.fm.settings.get("tmux_cwd_sync_now_focus", False):
+                    util.tmux("select-pane", "-t", pane_id)
 
 
 def tmux_cwd_sync_init(fm, setting, *args):
-    """"""
-
+    """Allows ranger to sync it's cwd to the other tmux pane."""
     fm.execute_console('map xc eval fm.execute_console("tmux_cwd_sync_now")')
 
     # Find pane with current instance of ranger in it


### PR DESCRIPTION
This adds an option which, when set, focuses the other tmux pane after `tmux_cwd_sync_now` is executed.

To activate this, add the following to ranger's `rc.conf` file:

```
set tmux_cwd_sync_now_focus true
```